### PR TITLE
Simplify codepoint_to_utf8()

### DIFF
--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -31,6 +31,7 @@ std::string render(Term::Window &scr, int rows, int cols,
     scr.print_str(1, y,   "Selected item: " + std::to_string(menupos));
     scr.print_str(1, y+1, "Menu width: " + std::to_string(menuwidth));
     scr.print_str(1, y+2, "Menu height: " + std::to_string(menuheight));
+    scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜ ");
 
     return scr.render();
 }

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -31,7 +31,7 @@ std::string render(Term::Window &scr, int rows, int cols,
     scr.print_str(1, y,   "Selected item: " + std::to_string(menupos));
     scr.print_str(1, y+1, "Menu width: " + std::to_string(menuwidth));
     scr.print_str(1, y+2, "Menu height: " + std::to_string(menuheight));
-    scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜ ");
+    scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ἐξήκοι");
 
     return scr.render();
 }

--- a/terminal.h
+++ b/terminal.h
@@ -464,26 +464,26 @@ utf8_decode_step(uint8_t state, uint8_t octet, uint32_t *cpp)
 /*----------------------------------------------------------------------------*/
 
 inline void codepoint_to_utf8(std::string &s, char32_t c) {
-    int nbytes;
-    if (c < 0x80) {
-        nbytes = 1;
-    } else if (c < 0x800) {
-        nbytes = 2;
-    } else if (c < 0x10000) {
-        nbytes = 3;
-    } else if (c <= 0x0010FFFF) {
-        nbytes = 4;
-    } else {
+    if (c > 0x0010FFFF) {
         throw std::runtime_error("Invalid UTF32 codepoint.");
     }
     char bytes[4];
-    static const unsigned char mask[4] = {0x00, 0xC0, 0xE0, 0xF0};
-    switch (nbytes) {
-        case 4: bytes[3] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 3: bytes[2] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 2: bytes[1] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 1: bytes[0] = static_cast<char>(c | mask[nbytes-1]);
+    int nbytes = 1;
+    char32_t d = c;
+    if (c >= 0x10000) {
+        nbytes++;
+        bytes[3] = ((d | 0x80) & 0xBF); d >>= 6;
     }
+    if (c >= 0x800) {
+        nbytes++;
+        bytes[2] = ((d | 0x80) & 0xBF); d >>= 6;
+    }
+    if (c >= 0x80) {
+        nbytes++;
+        bytes[1] = ((d | 0x80) & 0xBF); d >>= 6;
+    }
+    static const unsigned char mask[4] = {0x00, 0xC0, 0xE0, 0xF0};
+    bytes[0] = static_cast<char>(d | mask[nbytes-1]);
     s.append(bytes, nbytes);
 }
 

--- a/terminal.h
+++ b/terminal.h
@@ -476,15 +476,15 @@ inline void codepoint_to_utf8(std::string &s, char32_t c) {
     } else {
         throw std::runtime_error("Invalid UTF32 codepoint.");
     }
-    size_t m = s.size();
-    s.append(nbytes, 'x');
+    char bytes[4];
     static const unsigned char mask[4] = {0x00, 0xC0, 0xE0, 0xF0};
     switch (nbytes) {
-        case 4: s[m+3] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 3: s[m+2] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 2: s[m+1] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 1: s[m  ] = static_cast<char>(c | mask[nbytes-1]);
+        case 4: bytes[3] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 3: bytes[2] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 2: bytes[1] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 1: bytes[0] = static_cast<char>(c | mask[nbytes-1]);
     }
+    s.append(bytes, nbytes);
 }
 
 /*----------------------------------------------------------------------------*/

--- a/terminal.h
+++ b/terminal.h
@@ -476,20 +476,15 @@ inline void codepoint_to_utf8(std::string &s, char32_t c) {
     } else {
         throw std::runtime_error("Invalid UTF32 codepoint.");
     }
-    char u1('x'), u2('x'), u3('x'), u4('x');
+    size_t m = s.size();
+    s.append(nbytes, 'x');
     static const unsigned char mask[4] = {0x00, 0xC0, 0xE0, 0xF0};
     switch (nbytes) {
-        case 4: u4 = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 3: u3 = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 2: u2 = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
-        case 1: u1 =  static_cast<char>(c | mask[nbytes-1]);
+        case 4: s[m+3] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 3: s[m+2] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 2: s[m+1] = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
+        case 1: s[m  ] = static_cast<char>(c | mask[nbytes-1]);
     }
-    size_t idx = s.size();
-    s.append(std::string(nbytes, 'x'));
-    s[idx] = u1; idx++;
-    if (nbytes >= 2) { s[idx] = u2; idx++; }
-    if (nbytes >= 3) { s[idx] = u3; idx++; }
-    if (nbytes == 4) { s[idx] = u4; }
 }
 
 /*----------------------------------------------------------------------------*/

--- a/terminal.h
+++ b/terminal.h
@@ -484,20 +484,12 @@ inline void codepoint_to_utf8(std::string &s, char32_t c) {
         case 2: u2 = ((c | 0x80) & 0xBF); c >>= 6; /* fall through */
         case 1: u1 =  static_cast<char>(c | mask[nbytes-1]);
     }
-    switch (nbytes) {
-      case 1:
-        s.push_back(u1);
-        break;
-      case 2:
-        s.push_back(u1); s.push_back(u2);
-        break;
-      case 3:
-        s.push_back(u1); s.push_back(u2); s.push_back(u3);
-        break;
-      case 4:
-        s.push_back(u1); s.push_back(u2); s.push_back(u3); s.push_back(u4);
-        break;
-    }
+    size_t idx = s.size();
+    s.append(std::string(nbytes, 'x'));
+    s[idx] = u1; idx++;
+    if (nbytes >= 2) { s[idx] = u2; idx++; }
+    if (nbytes >= 3) { s[idx] = u3; idx++; }
+    if (nbytes == 4) { s[idx] = u4; }
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
I finally figured out how to really simplify the code. Now it is short and concise, and does not do any redundant operation.