### PR TITLE
Undefine colliding defines

### DIFF
--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -19,6 +19,25 @@
 #else
 #    include <sys/ioctl.h>
 #    include <termios.h>
+#undef B0
+#undef B50
+#undef B75
+#undef B110
+#undef B134
+#undef B150
+#undef B200
+#undef B300
+#undef B600
+#undef B1200
+#undef B1800
+#undef B2400
+#undef B4800
+#undef B9600
+#undef B19200
+#undef B28800
+#undef B38400
+#undef B57600
+#undef B115200
 #    include <unistd.h>
 #    include <errno.h>
 #endif


### PR DESCRIPTION
Fixes #35.

I actually do not like this. The fix looks ugly, and what if the user has a `B0` macro, then this would undefine it.

I think the solution is to split the code into a header and a cpp file. And import the `termios.h` in the cpp file, that way it won't collide with anything.

@KineticTheory let me know what you think.