### PR TITLE
Make read_raw() work when not connected to a tty

### DIFF
--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -172,6 +172,20 @@ public:
     // Returns true if a character is read, otherwise immediately returns false
     bool read_raw(char* s) const
     {
+        if (!keyboard_enabled) {
+            int c = getchar();
+            if (c >= 0) {
+                *s = c;
+            } else if (c == EOF) {
+                // In non-raw (blocking) mode this happens when the input file
+                // ends. In such a case, return the End of Transmission (EOT)
+                // character (Ctrl-D)
+                *s = 0x04;
+            } else {
+                throw std::runtime_error("getchar() failed");
+            }
+            return true;
+        }
 #ifdef _WIN32
         char buf[1];
         DWORD nread;


### PR DESCRIPTION
When not connected to a terminal, we are in a blocking mode. It is still
helpful to make `read_raw()` work, so that one can feed input to the
application by redirecting stdin, for example at a CI.