### PR TITLE
Automatically disable raw mode for non-tty

### DIFF
--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -70,8 +70,8 @@ public:
     BaseTerminal(bool enable_keyboard=false, bool /*disable_ctrl_c*/ = true)
         : keyboard_enabled{enable_keyboard}
     {
-        // Uncomment this to silently disable raw mode for non-tty
-        //if (keyboard_enabled) keyboard_enabled = is_stdin_a_tty();
+        // Silently disable raw mode for non-tty
+        if (keyboard_enabled) keyboard_enabled = is_stdin_a_tty();
         out_console = is_stdout_a_tty();
         if (out_console) {
             hout = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -113,8 +113,8 @@ public:
     BaseTerminal(bool enable_keyboard=false, bool disable_ctrl_c=true)
         : keyboard_enabled{enable_keyboard}
     {
-        // Uncomment this to silently disable raw mode for non-tty
-        //if (keyboard_enabled) keyboard_enabled = is_stdin_a_tty();
+        // Silently disable raw mode for non-tty
+        if (keyboard_enabled) keyboard_enabled = is_stdin_a_tty();
         if (keyboard_enabled) {
             if (tcgetattr(STDIN_FILENO, &orig_termios) == -1) {
                 throw std::runtime_error("tcgetattr() failed");


### PR DESCRIPTION
This change automatically disables raw mode when not connected to a
terminal. This seems to be a more useful default, which allows to
redirect input from a file, e.g., at a CI. Things will just work.